### PR TITLE
fix  #48 - changed link to images for jupyter book 

### DIFF
--- a/lectures/1.2_data_cube/1.2_data_cube.md
+++ b/lectures/1.2_data_cube/1.2_data_cube.md
@@ -18,7 +18,7 @@ When you think about data, most likely tables come to your mind, with features o
 - Feature: Revenue
 - Value: $
 
-![Datacube Economy](https://github.com/EO-College/cubes-and-clouds/blob/main/lectures/1.2_data_cube/assets/datacubes_economy.png "Example Data Cube Economy")
+![Datacube Economy](https://raw.githubusercontent.com/EO-College/cubes-and-clouds/main/lectures/1.2_data_cube/assets/datacubes_economy.png "Example Data Cube Economy")
 
 This concept can be applied to many fields such as economics, medicine, biology, and also very well to EO data!
 
@@ -32,12 +32,12 @@ The concept of representing multidimensional data as data cubes fits ideally to 
 
 Data can be represented as datacubes in EO, which are multi-dimensional arrays with additional information about their dimensionality. Datacubes can provide a nice and tidy interface for spatiotemporal data as well as for the operations you may want to execute on them. As they are arrays, it might be easiest to look at raster data as an example, even though datacubes can hold vector data as well. Our example data however consists of a 6x7 raster with 4 bands [`blue`, `green`, `red`, `near-infrared`] and 3 timesteps [`2020-10-01`, `2020-10-13`, `2020-10-25`], displayed here in an orderly, timeseries-like manner:
 
-![Raster datacube timeseries: 12 imagery tiles are depicted, grouped by 3 dates along a timeline (time dimension). Each date has a blue, green, red and near-infrared band (bands dimension). Each single tile has the dimensions x and y (spatial dimensions)](https://github.com/EO-College/cubes-and-clouds/blob/main/lectures/1.2_data_cube/assets/dc_timeseries.png "An examplary raster datacube with 4 dimensions: x, y, bands and time")
+![Raster datacube timeseries: 12 imagery tiles are depicted, grouped by 3 dates along a timeline (time dimension). Each date has a blue, green, red and near-infrared band (bands dimension). Each single tile has the dimensions x and y (spatial dimensions)](https://raw.githubusercontent.com/EO-College/cubes-and-clouds/main/lectures/1.2_data_cube/assets/dc_timeseries.png "An examplary raster datacube with 4 dimensions: x, y, bands and time")
 > Figure: An examplary raster datacube with 4 dimensions: x, y, bands and time. Reference: [openeo.org (2022). What are Data Cubes.](https://openeo.org/documentation/1.0/datacubes.html#what-are-datacubes)
 
 It is important to understand that datacubes are designed to make things easier for us, and are not literally a cube, meaning that the above plot is just as good a representation as any other. That is why we can switch the dimensions around and display them in whatever way we want, including the view below:
 
-![Raster datacube flat representation: The 12 imagery tiles are now laid out flat as a 4 by 3 grid (bands by timesteps). All dimension labels are depicted (The timestamps, the band names and the x, y coordinates)](https://github.com/EO-College/cubes-and-clouds/blob/main/lectures/1.2_data_cube/assets/dc_flat.png "This is the 'raw' data collection that is our example datacube. The grayscale images are colored for understandability, and dimension labels are displayed.")
+![Raster datacube flat representation: The 12 imagery tiles are now laid out flat as a 4 by 3 grid (bands by timesteps). All dimension labels are depicted (The timestamps, the band names and the x, y coordinates)](https://raw.githubusercontent.com/EO-College/cubes-and-clouds/main/lectures/1.2_data_cube/assets/dc_flat.png "This is the 'raw' data collection that is our example datacube. The grayscale images are colored for understandability, and dimension labels are displayed.")
 > Figure: Raster datacube flat representation: The 12 imagery tiles are now laid out flat as a 4 by 3 grid (bands by timesteps). All dimension labels are depicted (The timestamps, the band names and the x, y coordinates). Reference: [openeo.org (2022). What are Data Cubes.](https://openeo.org/documentation/1.0/datacubes.html#what-are-datacubes)
 
 ### Dimensions


### PR DESCRIPTION
I went through the rendered jupyter book https://eo-college.github.io/cubes-and-clouds and updated the links to images that were not rendered properly.