### PR TITLE
fix 404 openEO Platform webpage

### DIFF
--- a/lectures/2.1_data_discovery/2.1_data_discovery.md
+++ b/lectures/2.1_data_discovery/2.1_data_discovery.md
@@ -523,7 +523,7 @@ Earth observation data access is not limited to a single platform or a single en
 - [STAC Index](https://stacindex.org/catalogs): A list of publicly available STAC APIs and Static Catalogs.
 
 
-<iframe width="1000" height="600" src="https://openeo.cloud/data-collections/" title="openEO platform collections" frameborder="0" allowfullscreen></iframe>
+<iframe width="1000" height="600" src="https://documentation.dataspace.copernicus.eu/APIs/openEO/Collections.html" title="Copernicus Data Space collections" frameborder="0" allowfullscreen></iframe>
 
 ## How to search for data
 


### PR DESCRIPTION
Replaced openEO Platform webpage for data collections (unavailable) with the CDSE one.

Solving https://github.com/EO-College/cubes-and-clouds/issues/62